### PR TITLE
feat: Improve teacher screen sharing in lecture mode

### DIFF
--- a/hubs-compose/services/hubs/src/react-components/room/FocusLockAwareObjectMenu.js
+++ b/hubs-compose/services/hubs/src/react-components/room/FocusLockAwareObjectMenu.js
@@ -1,0 +1,44 @@
+import React, { useState, useEffect } from "react";
+import PropTypes from "prop-types";
+import { ObjectMenuContainer } from "./ObjectMenuContainer";
+import { useTeacherRole } from "./hooks/useTeacherRole";
+
+/**
+ * Wrapper for ObjectMenuContainer that hides the menu when 
+ * the student's view is locked by the teacher sharing content.
+ */
+export function FocusLockAwareObjectMenu(props) {
+    const { isTeacher } = useTeacherRole();
+    const [isFocusLocked, setIsFocusLocked] = useState(false);
+
+    // Check the global focus lock state
+    useEffect(() => {
+        const checkFocusLock = () => {
+            setIsFocusLocked(!!window.APP?.isFocusLocked);
+        };
+
+        // Check immediately
+        checkFocusLock();
+
+        // Poll for changes since it's a global variable
+        const interval = setInterval(checkFocusLock, 100);
+
+        return () => clearInterval(interval);
+    }, []);
+
+    // Hide object menu for non-teachers when focus is locked
+    if (!isTeacher && isFocusLocked) {
+        return null;
+    }
+
+    return <ObjectMenuContainer {...props} />;
+}
+
+FocusLockAwareObjectMenu.propTypes = {
+    hubChannel: PropTypes.object.isRequired,
+    scene: PropTypes.object.isRequired,
+    onOpenProfile: PropTypes.func.isRequired,
+    onGoToObject: PropTypes.func.isRequired
+};
+
+export default FocusLockAwareObjectMenu;

--- a/hubs-compose/services/hubs/src/react-components/room/ObjectMenu.scss
+++ b/hubs-compose/services/hubs/src/react-components/room/ObjectMenu.scss
@@ -26,8 +26,7 @@
 :local(.object-menu-container) {
   position: absolute;
   bottom: 16px;
-  left: 50%;
-  transform: translateX(-50%);
+  left: 16px;
   display: flex;
   flex-direction: column;
   pointer-events: auto;
@@ -106,6 +105,7 @@
 }
 
 :global(.keyboard-user) {
+
   :local(.back-button):focus,
   :local(.object-menu-container) :focus {
     box-shadow: 0 0 0 3px theme.$white;

--- a/hubs-compose/services/hubs/src/react-components/room/ShareToStudentsButton.js
+++ b/hubs-compose/services/hubs/src/react-components/room/ShareToStudentsButton.js
@@ -1,0 +1,161 @@
+import React, { useState, useEffect, useCallback } from "react";
+import PropTypes from "prop-types";
+import { FormattedMessage } from "react-intl";
+import { useLectureMode } from "./hooks/useLectureMode";
+import { Button } from "../input/Button";
+import styles from "./ShareToStudentsButton.scss";
+import { CAMERA_MODE_INSPECT } from "../../systems/camera-system";
+
+/**
+ * A floating button that appears when a teacher is inspecting an object in lecture mode.
+ * Allows teachers to share the currently inspected object with all students.
+ */
+export function ShareToStudentsButton({ scene }) {
+    const {
+        isTeacher,
+        lectureModeEnabled,
+        shareFocusToStudents,
+        releaseFocusShare,
+        sharedFocusTarget
+    } = useLectureMode();
+
+    const [isInspecting, setIsInspecting] = useState(false);
+
+    // Listen for inspect events and camera mode changes
+    useEffect(() => {
+        if (!scene) return;
+
+        const checkInspectState = () => {
+            const cameraSystem = scene.systems?.["hubs-systems"]?.cameraSystem;
+            if (cameraSystem && cameraSystem.mode === CAMERA_MODE_INSPECT && cameraSystem.inspectable) {
+                setIsInspecting(true);
+            } else {
+                setIsInspecting(false);
+            }
+        };
+
+        scene.addEventListener("inspect-target-changed", checkInspectState);
+        const interval = setInterval(checkInspectState, 500);
+        checkInspectState();
+
+        return () => {
+            scene.removeEventListener("inspect-target-changed", checkInspectState);
+            clearInterval(interval);
+        };
+    }, [scene]);
+
+    // Handle share button click - shares network ID of the object
+    const handleShare = useCallback(() => {
+        if (!scene) return;
+
+        const cameraSystem = scene.systems?.["hubs-systems"]?.cameraSystem;
+        if (!cameraSystem || !cameraSystem.inspectable) return;
+
+        const inspectable = cameraSystem.inspectable;
+        let objectName = "shared content";
+        let networkId = null;
+
+        // Try to get the network ID from the A-Frame element
+        if (inspectable?.el) {
+            // Get network ID from NAF component
+            const nafComp = inspectable.el.components?.["networked"];
+            if (nafComp) {
+                networkId = nafComp.data?.networkId || nafComp.networkId;
+            }
+
+            // Try to get name
+            const mediaInfo = inspectable.el.getAttribute?.("media-loader");
+            if (mediaInfo?.src) {
+                try {
+                    const url = new URL(mediaInfo.src);
+                    objectName = url.pathname.split('/').pop() || objectName;
+                } catch (e) { }
+            }
+        }
+
+        // If no network ID found, try to find it in parent elements
+        if (!networkId && inspectable?.el) {
+            let el = inspectable.el;
+            while (el && !networkId) {
+                const nafComp = el.components?.["networked"];
+                if (nafComp) {
+                    networkId = nafComp.data?.networkId || nafComp.networkId;
+                }
+                el = el.parentElement;
+            }
+        }
+
+        if (networkId) {
+            shareFocusToStudents(networkId, objectName);
+        } else {
+            console.warn("[ShareToStudentsButton] Could not find network ID for inspected object");
+            // Fallback to position-based sharing
+            const pivot = cameraSystem.pivot;
+            if (pivot) {
+                const pos = pivot.getWorldPosition ? pivot.getWorldPosition(new THREE.Vector3()) : pivot.position;
+                shareFocusToStudents({ position: { x: pos.x, y: pos.y, z: pos.z } }, objectName);
+            }
+        }
+    }, [scene, shareFocusToStudents]);
+
+    // Handle release button click
+    const handleRelease = useCallback(() => {
+        releaseFocusShare();
+    }, [releaseFocusShare]);
+
+    // Only show for teachers in lecture mode
+    if (!isTeacher || !lectureModeEnabled) {
+        return null;
+    }
+
+    // Show release button if currently sharing
+    if (sharedFocusTarget) {
+        return (
+            <div className={styles.shareToStudentsContainer}>
+                <div className={styles.sharingIndicator}>
+                    <span className={styles.sharingDot}></span>
+                    <FormattedMessage
+                        id="share-to-students.sharing"
+                        defaultMessage="Sharing with students"
+                    />
+                </div>
+                <Button
+                    preset="cancel"
+                    onClick={handleRelease}
+                    className={styles.releaseButton}
+                >
+                    <FormattedMessage
+                        id="share-to-students.stop"
+                        defaultMessage="Stop Sharing"
+                    />
+                </Button>
+            </div>
+        );
+    }
+
+    // Show share button if inspecting
+    if (isInspecting) {
+        return (
+            <div className={styles.shareToStudentsContainer}>
+                <Button
+                    preset="accept"
+                    onClick={handleShare}
+                    className={styles.shareButton}
+                >
+                    <FormattedMessage
+                        id="share-to-students.share"
+                        defaultMessage="Share with Students"
+                    />
+                </Button>
+            </div>
+        );
+    }
+
+    return null;
+}
+
+ShareToStudentsButton.propTypes = {
+    scene: PropTypes.object
+};
+
+export default ShareToStudentsButton;

--- a/hubs-compose/services/hubs/src/react-components/room/ShareToStudentsButton.scss
+++ b/hubs-compose/services/hubs/src/react-components/room/ShareToStudentsButton.scss
@@ -1,0 +1,94 @@
+@use "../styles/theme.scss";
+
+:local(.shareToStudentsContainer) {
+    position: fixed;
+    top: 80px;
+    left: 20px;
+    z-index: 1000;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 8px;
+    padding: 12px 16px;
+    background: rgba(0, 0, 0, 0.8);
+    border-radius: 12px;
+    backdrop-filter: blur(10px);
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
+}
+
+:local(.sharingIndicator) {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    color: #fff;
+    font-size: 14px;
+    font-weight: 500;
+}
+
+:local(.sharingDot) {
+    width: 10px;
+    height: 10px;
+    background: #ff4444;
+    border-radius: 50%;
+    animation: pulse 1.5s infinite;
+}
+
+@keyframes pulse {
+
+    0%,
+    100% {
+        opacity: 1;
+        transform: scale(1);
+    }
+
+    50% {
+        opacity: 0.6;
+        transform: scale(1.2);
+    }
+}
+
+:local(.shareButton) {
+    background: linear-gradient(135deg, #4CAF50, #45a049) !important;
+    color: white !important;
+    border: none !important;
+    padding: 10px 20px !important;
+    font-size: 14px !important;
+    font-weight: 600 !important;
+    border-radius: 8px !important;
+    cursor: pointer !important;
+    transition: all 0.2s ease !important;
+    box-shadow: 0 2px 8px rgba(76, 175, 80, 0.4) !important;
+
+    &:hover {
+        background: linear-gradient(135deg, #45a049, #3d8b40) !important;
+        transform: translateY(-1px);
+        box-shadow: 0 4px 12px rgba(76, 175, 80, 0.5) !important;
+    }
+
+    &:active {
+        transform: translateY(0);
+    }
+}
+
+:local(.releaseButton) {
+    background: linear-gradient(135deg, #f44336, #d32f2f) !important;
+    color: white !important;
+    border: none !important;
+    padding: 10px 20px !important;
+    font-size: 14px !important;
+    font-weight: 600 !important;
+    border-radius: 8px !important;
+    cursor: pointer !important;
+    transition: all 0.2s ease !important;
+    box-shadow: 0 2px 8px rgba(244, 67, 54, 0.4) !important;
+
+    &:hover {
+        background: linear-gradient(135deg, #d32f2f, #b71c1c) !important;
+        transform: translateY(-1px);
+        box-shadow: 0 4px 12px rgba(244, 67, 54, 0.5) !important;
+    }
+
+    &:active {
+        transform: translateY(0);
+    }
+}

--- a/hubs-compose/services/hubs/src/react-components/room/StudentFocusLock.js
+++ b/hubs-compose/services/hubs/src/react-components/room/StudentFocusLock.js
@@ -1,0 +1,104 @@
+import React, { useState, useEffect, useCallback } from "react";
+import { FormattedMessage } from "react-intl";
+import { useTeacherRole } from "./hooks/useTeacherRole";
+import { Button } from "../input/Button";
+import styles from "./StudentFocusLock.scss";
+
+/**
+ * Displays a banner when the teacher is sharing content.
+ * For students, shows a "View" button that they can click
+ * to inspect the same object the teacher is sharing.
+ */
+export function StudentFocusLock() {
+    const { isTeacher } = useTeacherRole();
+    const [sharedNetworkId, setSharedNetworkId] = useState(null);
+    const [isSharing, setIsSharing] = useState(false);
+    const [objectName, setObjectName] = useState("shared content");
+
+    // Listen for focus share messages
+    useEffect(() => {
+        const scene = AFRAME.scenes[0];
+        if (!scene) return;
+
+        const messageDispatch = APP.messageDispatch;
+        if (!messageDispatch) return;
+
+        const onMessage = (event) => {
+            const message = event.detail;
+
+            if (message.type === "focus_share") {
+                const networkId = message.body?.networkId;
+                const name = message.body?.objectName || "shared content";
+                if (networkId) {
+                    setSharedNetworkId(networkId);
+                    setObjectName(name);
+                    setIsSharing(true);
+                }
+            }
+
+            if (message.type === "focus_release") {
+                setSharedNetworkId(null);
+                setIsSharing(false);
+            }
+        };
+
+        messageDispatch.addEventListener("message", onMessage);
+
+        return () => {
+            messageDispatch.removeEventListener("message", onMessage);
+        };
+    }, []);
+
+    // Handle View button click - find the object by network ID and inspect it
+    const handleReturnToView = useCallback(() => {
+        if (!sharedNetworkId) return;
+
+        try {
+            const scene = AFRAME.scenes[0];
+            if (!scene) return;
+
+            // Find the entity by network ID using NAF
+            const entity = NAF.entities.getEntity(sharedNetworkId);
+            if (entity && entity.object3D) {
+                // Use camera system to inspect the object
+                const cameraSystem = scene.systems?.["hubs-systems"]?.cameraSystem;
+                if (cameraSystem) {
+                    cameraSystem.inspect(entity.object3D, 1.5, true);
+                }
+            } else {
+                console.warn("[StudentFocusLock] Could not find entity with network ID:", sharedNetworkId);
+                scene.emit("chat_notification", {
+                    message: "⚠️ Could not find the shared object"
+                });
+            }
+        } catch (err) {
+            console.error("[StudentFocusLock] Error inspecting shared object:", err);
+        }
+    }, [sharedNetworkId]);
+
+    // Don't show for teachers or when not sharing
+    if (isTeacher || !isSharing) {
+        return null;
+    }
+
+    return (
+        <div className={styles.focusLockOverlay}>
+            <div className={styles.focusLockBadge}>
+                <span className={styles.eyeIcon}>👁️</span>
+                <span>Teacher is sharing: {objectName}</span>
+                <Button
+                    preset="basic"
+                    onClick={handleReturnToView}
+                    className={styles.returnButton}
+                >
+                    <FormattedMessage
+                        id="student-focus-lock.view"
+                        defaultMessage="View"
+                    />
+                </Button>
+            </div>
+        </div>
+    );
+}
+
+export default StudentFocusLock;

--- a/hubs-compose/services/hubs/src/react-components/room/StudentFocusLock.scss
+++ b/hubs-compose/services/hubs/src/react-components/room/StudentFocusLock.scss
@@ -1,0 +1,65 @@
+@use "../styles/theme.scss";
+
+:local(.focusLockOverlay) {
+    position: fixed;
+    top: 0;
+    left: 0;
+    pointer-events: none;
+    z-index: 999;
+}
+
+:local(.focusLockBadge) {
+    position: fixed;
+    top: 80px;
+    left: 20px;
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 10px 16px;
+    background: linear-gradient(135deg, rgba(33, 150, 243, 0.95), rgba(25, 118, 210, 0.95));
+    color: white;
+    border-radius: 12px;
+    font-size: 14px;
+    font-weight: 600;
+    box-shadow: 0 4px 20px rgba(33, 150, 243, 0.4);
+    animation: slideIn 0.3s ease-out;
+    pointer-events: auto;
+}
+
+:local(.eyeIcon) {
+    font-size: 18px;
+}
+
+:local(.returnButton) {
+    background: rgba(255, 255, 255, 0.2) !important;
+    color: white !important;
+    border: 1px solid rgba(255, 255, 255, 0.5) !important;
+    padding: 6px 14px !important;
+    font-size: 12px !important;
+    font-weight: 600 !important;
+    border-radius: 20px !important;
+    cursor: pointer !important;
+    transition: all 0.2s ease !important;
+    min-height: unset !important;
+
+    &:hover {
+        background: rgba(255, 255, 255, 0.35) !important;
+        transform: scale(1.02);
+    }
+
+    &:active {
+        transform: scale(0.98);
+    }
+}
+
+@keyframes slideIn {
+    from {
+        opacity: 0;
+        transform: translateX(-20px);
+    }
+
+    to {
+        opacity: 1;
+        transform: translateX(0);
+    }
+}

--- a/hubs-compose/services/hubs/src/react-components/ui-root.js
+++ b/hubs-compose/services/hubs/src/react-components/ui-root.js
@@ -55,6 +55,8 @@ import { WhiteboardSidebar } from "./room/WhiteboardSidebar";
 import { AttendanceSidebar } from "./room/AttendanceSidebar";
 import { TeacherToolbarButtons } from "./room/TeacherToolbarButtons";
 import { HandRaiseNotification } from "./room/HandRaiseNotification";
+import { ShareToStudentsButton } from "./room/ShareToStudentsButton";
+import { StudentFocusLock } from "./room/StudentFocusLock";
 import { ContentMenu, PeopleMenuButton, ObjectsMenuButton, ECSDebugMenuButton } from "./room/ContentMenu";
 import { ReactComponent as CameraIcon } from "./icons/Camera.svg";
 import { ReactComponent as AvatarIcon } from "./icons/Avatar.svg";
@@ -1609,6 +1611,8 @@ class UIRoot extends Component {
                       onClose={() => this.setState({ showAttendance: false })}
                     />
                     <HandRaiseNotification />
+                    <ShareToStudentsButton scene={this.props.scene} />
+                    <StudentFocusLock />
                   </>
                 }
                 toolbarLeft={

--- a/hubs-compose/services/hubs/src/systems/camera-system.js
+++ b/hubs-compose/services/hubs/src/systems/camera-system.js
@@ -371,6 +371,71 @@ export class CameraSystem {
     }
   }
 
+  // Inspect at a world position without needing an entity
+  // Used for teacher-shared content viewing
+  inspectAtPosition(worldPosition, distanceMod = 1.5, fireChangeEvent = true) {
+    this.verticalDelta = 0;
+    this.horizontalDelta = 0;
+    this.inspectZoom = 0;
+
+    if (this.mode === CAMERA_MODE_INSPECT) {
+      return;
+    }
+
+    const scene = AFRAME.scenes[0];
+
+    // Create a temporary pivot object at the target position
+    if (!this._positionInspectPivot) {
+      this._positionInspectPivot = new THREE.Object3D();
+      this._positionInspectPivot.name = "PositionInspectPivot";
+      scene.object3D.add(this._positionInspectPivot);
+    }
+
+    // Position the pivot at the shared location
+    this._positionInspectPivot.position.set(worldPosition.x, worldPosition.y, worldPosition.z);
+    this._positionInspectPivot.updateMatrixWorld(true);
+
+    scene.object3D.traverse(ensureLightsAreSeenByCamera);
+    scene.classList.add("hand-cursor");
+    scene.classList.remove("no-cursor");
+    this.snapshot.mode = this.mode;
+    this.mode = CAMERA_MODE_INSPECT;
+    this.inspectable = this._positionInspectPivot;
+    this.pivot = this._positionInspectPivot;
+
+    const camera = scene.is("vr-mode") ? scene.renderer.xr.getCamera() : scene.camera;
+    this.snapshot.mask = camera.layers.mask;
+
+    // Show lights/background since there's no specific object to focus on
+    camera.layers.disable(Layers.CAMERA_LAYER_FIRST_PERSON_ONLY);
+    camera.layers.enable(Layers.CAMERA_LAYER_THIRD_PERSON_ONLY);
+
+    this.viewingCamera.updateMatrices();
+    this.snapshot.matrixWorld.copy(this.viewingRig.object3D.matrixWorld);
+    this.snapshot.audio = null;
+
+    this.ensureListenerIsParentedCorrectly(scene);
+
+    // Position camera to look at the pivot
+    const rigPos = this.viewingRig.object3D.position.clone();
+    const targetPos = this._positionInspectPivot.position.clone();
+    const distance = rigPos.distanceTo(targetPos);
+    const viewDist = Math.max(distance * 0.8, 2) * distanceMod;
+
+    // Calculate camera position at a distance from the target
+    const direction = new THREE.Vector3().subVectors(rigPos, targetPos).normalize();
+    const cameraPos = targetPos.clone().add(direction.multiplyScalar(viewDist));
+    cameraPos.y = Math.max(cameraPos.y, targetPos.y + 0.5); // Slightly above
+
+    this.viewingRig.object3D.position.copy(cameraPos);
+    this.viewingCamera.lookAt(targetPos);
+    this.viewingRig.object3D.updateMatrixWorld(true);
+
+    if (fireChangeEvent) {
+      scene.emit("inspect-target-changed");
+    }
+  }
+
   toggleLights() {
     this.lightsEnabled = !this.lightsEnabled;
     localStorage.setItem("show-background-while-inspecting", this.lightsEnabled.toString());
@@ -477,6 +542,13 @@ export class CameraSystem {
           }
         }
       } else if (this.mode === CAMERA_MODE_INSPECT && this.userinput.get(paths.actions.stopInspecting)) {
+        // Check if focus is locked by teacher sharing content
+        const isFocusLocked = window.APP?.isFocusLocked;
+        if (isFocusLocked) {
+          // Prevent exiting inspect mode when focus is locked
+          return;
+        }
+
         scene.emit("uninspect");
         if (shouldUseNewLoader()) {
           const inspected = anyEntityWith(APP.world, Inspected);


### PR DESCRIPTION
## Summary
Adds the ability for teachers to share specific objects with students during lecture mode. When a teacher inspects an object and clicks "Share with Students", all students see a notification and can click "View" to inspect the same object.
## Features
- Teachers can share any inspected object with students via a floating button
- Students receive a notification banner with a "View" button
- Clicking "View" puts students in inspect mode on the shared object